### PR TITLE
Add side icon to campaign Discord presence

### DIFF
--- a/DXMainClient/DXGUI/Generic/CampaignSelector.cs
+++ b/DXMainClient/DXGUI/Generic/CampaignSelector.cs
@@ -325,7 +325,7 @@ namespace DTAClient.DXGUI.Generic
 
             ((MainMenuDarkeningPanel)Parent).Hide();
 
-            discordHandler?.UpdatePresence(mission.GUIName, difficultyName, true);
+            discordHandler?.UpdatePresence(mission.GUIName, difficultyName, mission.IconPath, true);
             GameProcessLogic.GameProcessExited += GameProcessExited_Callback;
 
             GameProcessLogic.StartGameProcess();

--- a/DXMainClient/Domain/DiscordHandler.cs
+++ b/DXMainClient/Domain/DiscordHandler.cs
@@ -196,15 +196,18 @@ namespace DTAClient.Domain
         /// <summary>
         /// Updates Discord Rich Presence with info from campaign screen.
         /// </summary>
-        public void UpdatePresence(string mission, string difficulty, bool resetTimer = false)
+        public void UpdatePresence(string mission, string difficulty, string side, bool resetTimer = false)
         {
+            string sideKey = new Regex("[^a-zA-Z0-9]").Replace(side.ToLower(), "");
             CurrentPresence = new RichPresence()
             {
                 State = "Playing Mission",
                 Details = $"{mission} • {difficulty}",
                 Assets = new Assets()
                 {
-                    LargeImageKey = "logo"
+                    LargeImageKey = "logo",
+                    SmallImageKey = sideKey,
+                    SmallImageText = side
                 },
                 Timestamps = (client.CurrentPresence.HasTimestamps() && !resetTimer) ?
                     client.CurrentPresence.Timestamps : Timestamps.Now


### PR DESCRIPTION
Overlooked the availability of icon info, so fixed this with a commit. The logic to look up a key is the same as with multiplayer/skirmish sides, only using SideName ini param instead of name in sides list.